### PR TITLE
Optimizes Mapillary flow by pulling and unique-ing sequence IDs first

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ To summarize, Valhalla is capable of building routing tilesets and running route
 time of arrival can be fairly inaccurate, especially in urban areas with high traffic. The estimated speeds were more
 akin to driving alone at night, which is not ideal since most people drive in the day in urbanized areas.
 
-Conflation aims to provide a *statistical approach* to estimating of driving speeds. Specifically, this project
-estimates speeds across different road classes using open-source GPS trace data. The road classes used will be taken
+Conflation aims to provide a *statistical approach* to estimating driving speeds. Specifically, this project estimates
+speeds across different road classes using open-source GPS trace data. The road classes used will be taken
 from [OpenStreetMap (OSM)](https://www.openstreetmap.org/), which delineates between motorways, trunks, primary roads,
 secondary roads, residential, etc. To further refine our estimates, we will also split up our results by geographic
 area (country and region), as well as by urban, suburban, and rural settings.
@@ -31,7 +31,7 @@ area (country and region), as well as by urban, suburban, and rural settings.
 A high-level methodology of this script is as follows:
 
 1. Create an `output/` folder where results will be stored.
-    1. This script store intermediate results on disk, so that if a run is interrupted (either intentionally or
+    1. This script stores intermediate results on disk, so that if a run is interrupted (either intentionally or
        accidentally) it can automatically pick up from where it left off. Since we eventually intend to have this script
        runnable on the entire planet, not having to make repeated API calls or repeat calculations will be useful.
     2. This script also will store the final results in this output folder (`output/results/`).
@@ -87,10 +87,10 @@ There is a specific JSON structure that this script outputs. Here is an example:
 
 ### Quickstart Example
 
-This project uses Python 3.9. The script can be run by setting up a virtualenv, installing modules from 
+This project uses Python 3.9. The script can be run by setting up a virtualenv, installing modules from
 `requirements.txt`, and calling the `conflation/main.py` script.
 
-Here is an example setup and run across a wide area in Manhattan NYC, with Mapillary client ID redacted (assuming you 
+Here is an example setup and run across a wide area in Manhattan NYC, with Mapillary client ID redacted (assuming you
 have Python 3.9 installed using `python3`):
 
 ```bash
@@ -104,7 +104,7 @@ python3 -m conflation --bbox=...
 
 ### Arguments
 
- There are a few args that need to be specified:
+There are a few args that need to be specified:
 
 | Argument | Behavior |
 |----------|----------|
@@ -116,7 +116,7 @@ python3 -m conflation --bbox=...
 For the `--trace-config` and `--map-matching-config` arguments, JSONs needs to be specified as the value. Here are the
 keys accepted by both JSONs:
 
-####--trace-config
+#### --trace-config
 
 Currently, only Mapillary is supported as an API trace provider. The JSON can hold the following keys:
 
@@ -129,7 +129,18 @@ Currently, only Mapillary is supported as an API trace provider. The JSON can ho
 | `max_sequences_per_bbox_section` | Optional - Number of Mapillary sequences that should be pulled for each bbox section (i.e each zoom 14 tile). Default = 500 |
 | `skip_if_fewer_imgs_than` | Optional - Skip a Mapillary sequence if it has fewer Mapillary images than this value. Default = 30 |
 
-####--map-matching-config
+##### Mapillary API Client Secret
+You can obtain a client secret by doing the following (instructions last updated 11/2021):
+* Go to www.mapillary.com, create an account or log in
+* Click on Dashboard (top right corner)
+* Click on "Developers" on the left sidebar
+* Click on "Register application" and fill out the form
+  * Feel free to simply use http://localhost:8080/ as the "Callback URL" and https://github.com/OpenStreetMapSpeeds as the "Company website"
+  * Allow this application to READ
+* Click on "View" under "Client secret" once the application is created
+* It will look something like this: `MLY|123456789|abcd1234` – only the part after the second `|` is necessary (i.e. `"client_secret":"abcd1234"`)
+
+#### --map-matching-config
 
 Currently, only Valhalla is supported as a map matching provider. The JSON can hold the following keys:
 
@@ -139,7 +150,6 @@ Currently, only Valhalla is supported as a map matching provider. The JSON can h
 | `base_url` | The base URL of your running Valhalla service (example format: `https://aws.my.valhalla.com/`)  |
 | `headers` | Optional - Headers JSON that will be passed along in each call to Valhalla |
 
-
 ## Contributing
 
 We welcome contributions to Conflation. If you would like to report an issue, or even better fix an existing one, please
@@ -147,7 +157,9 @@ use the [Conflation issue tracker](https://github.com/OpenStreetMapSpeeds/confla
 
 To install the project in development mode plus the needed libraries, do a `pip install -e ".[dev]"`.
 
-We encourage you to install the pre-commit hooks by typing `pre-commit install` which will run the following commands to lint and style-check your code before committing:
+We encourage you to install the pre-commit hooks by typing `pre-commit install` which will run the following commands to
+lint and style-check your code before committing:
+
 ```shell script
 flake8 .
 black .

--- a/README.md
+++ b/README.md
@@ -130,15 +130,19 @@ Currently, only Mapillary is supported as an API trace provider. The JSON can ho
 | `skip_if_fewer_imgs_than` | Optional - Skip a Mapillary sequence if it has fewer Mapillary images than this value. Default = 30 |
 
 ##### Mapillary API Client Secret
+
 You can obtain a client secret by doing the following (instructions last updated 11/2021):
+
 * Go to www.mapillary.com, create an account or log in
 * Click on Dashboard (top right corner)
 * Click on "Developers" on the left sidebar
 * Click on "Register application" and fill out the form
-  * Feel free to simply use http://localhost:8080/ as the "Callback URL" and https://github.com/OpenStreetMapSpeeds as the "Company website"
-  * Allow this application to READ
+    * Feel free to simply use http://localhost:8080/ as the "Callback URL" and https://github.com/OpenStreetMapSpeeds as
+      the "Company website"
+    * Allow this application to READ
 * Click on "View" under "Client secret" once the application is created
-* It will look something like this: `MLY|123456789|abcd1234` – only the part after the second `|` is necessary (i.e. `"client_secret":"abcd1234"`)
+* It will look something like this: `MLY|123456789|abcd1234` – only the part after the second `|` is necessary (
+  i.e. `"client_secret":"abcd1234"`)
 
 #### --map-matching-config
 

--- a/conflation/main.py
+++ b/conflation/main.py
@@ -3,6 +3,7 @@ import argparse
 import json
 import multiprocessing
 import shutil
+import time
 
 from conflation import aggregation, util
 from conflation.map_matching import valhalla
@@ -38,6 +39,9 @@ def main():
     )
 
     # TODO: Change print() to use logger and add logging level as arg
+
+    # Log time taken for the run
+    start = time.time()
 
     parsed_args = arg_parser.parse_args()
 
@@ -115,7 +119,9 @@ def main():
     # Delete the tmp dir since we are finished with the run
     shutil.rmtree(tmp_dir)
 
-    print("Done!")
+    # Print out the time elapsed for this entire run
+    end = time.time()
+    print("Script finished run in {} seconds.".format(end - start))
 
 
 if __name__ == "__main__":

--- a/conflation/main.py
+++ b/conflation/main.py
@@ -2,6 +2,7 @@
 import argparse
 import json
 import multiprocessing
+import shutil
 
 from conflation import aggregation, util
 from conflation.map_matching import valhalla
@@ -110,6 +111,9 @@ def main():
     # each row is a per-edge measurement
     print("Map matching complete, aggregating data into final .json output files...")
     aggregation.run(map_matches_dir, results_dir)
+
+    # Delete the tmp dir since we are finished with the run
+    shutil.rmtree(tmp_dir)
 
     print("Done!")
 

--- a/conflation/trace_fetching/mapillary.py
+++ b/conflation/trace_fetching/mapillary.py
@@ -298,7 +298,6 @@ def pull_filter_and_save_trace_for_sequence_ids(
         # Avoids potential partial write issues by writing to a temp file and then as a final operation, then renaming
         # to the real location
         temp_filename = os.path.join(global_tmp_dir, os.path.basename(trace_filename))
-        print(temp_filename)
         pickle.dump(trace_data, open(temp_filename, "wb"))
         os.rename(temp_filename, trace_filename)
 

--- a/conflation/trace_fetching/mapillary.py
+++ b/conflation/trace_fetching/mapillary.py
@@ -251,7 +251,7 @@ def pull_filter_and_save_trace_for_sequence_ids(
 ) -> None:
     """
     First, check to see if a sequence ID block already has trace data pulled onto disk. If not, pull it from Mapillary
-    by calling make_trace_data_requests(), filter it using trace_filer.run(), and save it to disk. There is a Meant to
+    by calling make_trace_data_requests(), filter it using trace_filer.run(), and save it to disk. This is meant to
     be run in a multi-threaded manner and references global vars made by initialize_multiprocess().
 
     :param sequence_id_blocks: tuple where [0] index: list of sequence IDs to pull traces for, [1] index: the filename

--- a/conflation/trace_fetching/mapillary.py
+++ b/conflation/trace_fetching/mapillary.py
@@ -30,6 +30,11 @@ IMAGES_URL = "https://graph.mapillary.com/images?fields=captured_at,geometry&ima
 COVERAGE_ZOOM = 5
 # We then perform the actual search for trace sequences at zoom 14
 BBOX_SECTION_ZOOM = 14
+# The size of the sequence ID blocks that each thread will handle when pulling images
+SEQUENCE_ID_BLOCK_SIZE = 10
+
+# Name of the dir where we store sequence IDs pulled from Mapillary
+SEQUENCE_IDS_DIR_NAME = "seq_ids"
 
 
 def run(
@@ -68,15 +73,17 @@ def run(
         start_date - datetime.datetime.utcfromtimestamp(0)
     ).total_seconds() * 1000.0
 
+    # Create a dir to store sequence IDs that we pull from Mapillary
+    sequence_ids_dir = os.path.join(tmp_dir, SEQUENCE_IDS_DIR_NAME)
+
     # Break the bbox into sections and save it to a pickle file
-    bbox_sections = split_bbox(session, traces_dir, bbox, access_token, start_date_epoch)
+    bbox_sections = split_bbox(session, sequence_ids_dir, bbox, access_token, start_date_epoch)
 
     finished_bbox_sections = multiprocessing.Value("i", 0)
+    finished_sequence_id_blocks = multiprocessing.Value("i", 0)
 
     # Adding these "temporary" counters so that we can make some estimates of how much time is wasted due to seeing
     # duplicate sequences across different z14 tiles
-    pulled_sequences = multiprocessing.Value("i", 0)
-    skipped_sequences_due_to_origin_coordinate = multiprocessing.Value("i", 0)
     skipped_sequences_due_to_filters = multiprocessing.Value("i", 0)
 
     with multiprocessing.Pool(
@@ -87,21 +94,66 @@ def run(
             tmp_dir,
             config,
             finished_bbox_sections,
+            finished_sequence_id_blocks,
             start_date_epoch,
-            pulled_sequences,
-            skipped_sequences_due_to_origin_coordinate,
             skipped_sequences_due_to_filters,
         ),
         processes=processes,
     ) as pool:
-        result = pool.map_async(pull_filter_and_save_trace_for_bbox, bbox_sections)
+        # Run the multiprocess job that takes all the bbox_sections, and pulls all the sequence IDs that are within each
+        # section
+        result = pool.map_async(pull_sequence_ids_for_bbox, bbox_sections)
 
-        print("Placing {} results in {}...".format(len(bbox_sections), traces_dir))
+        # This file holds the blocks of unique sequence IDs that we've pulled from Mapillary. See if it already exists;
+        # if it does then we don't need to pull sequence IDs from Mapillary again
+        traces_sections_filename = util.get_sections_filename(traces_dir)
+        try:
+            print("Reading sequence ID sections from disk...")
+            bbox_sections: list[tuple[int, int, str]] = pickle.load(
+                open(traces_sections_filename, "rb")
+            )
+        except (OSError, IOError):
+            print("Sequence ID sections pickle not found. Creating and writing to disk...")
+            print(
+                "Placing {} sequence IDs from z14 tiles in {}...".format(
+                    len(bbox_sections), sequence_ids_dir
+                )
+            )
+            progress = 0
+            increment = 5
+            while not result.ready():
+                result.wait(timeout=5)
+                next_progress = int(finished_bbox_sections.value / len(bbox_sections) * 100)
+                if int(next_progress / increment) > progress:
+                    print("Current progress: {}%".format(next_progress))
+                    progress = int(next_progress / increment)
+            if progress != 100 / increment:
+                print("Current progress: 100%")
+
+            # Get all the unique sequence IDs that were pulled from the previous step
+            print(
+                "Reading sequence IDs from all z14 tiles and generating blocks of {} unique sequence IDs...".format(
+                    SEQUENCE_ID_BLOCK_SIZE
+                )
+            )
+            sequence_id_blocks = find_unique_sequence_ids(bbox_sections, traces_dir)
+
+            pickle.dump(sequence_id_blocks, open(traces_sections_filename, "wb"))
+
+        # Run the multiprocess job that goes through all unique sequence IDs and actually pulls the images / coordinates
+        # for each sequence
+        result = pool.map_async(
+            pull_filter_and_save_trace_for_sequence_ids, sequence_id_blocks
+        )
+
+        print("Placing {} results in {}...".format(len(sequence_id_blocks), traces_dir))
         progress = 0
         increment = 5
         while not result.ready():
             result.wait(timeout=5)
-            next_progress = int(finished_bbox_sections.value / len(bbox_sections) * 100)
+            next_progress = int(
+                finished_sequence_id_blocks.value / len(sequence_id_blocks) * 100
+            )
             if int(next_progress / increment) > progress:
                 print("Current progress: {}%".format(next_progress))
                 progress = int(next_progress / increment)
@@ -109,11 +161,8 @@ def run(
             print("Current progress: 100%")
 
         print(
-            "Pulled {} sequences. Skipped {} of these sequences because they were duplicates (not originating in "
-            "the current-processing bbox). Skipped {} of these sequences because of filters.".format(
-                pulled_sequences.value,
-                skipped_sequences_due_to_origin_coordinate.value,
-                skipped_sequences_due_to_filters.value,
+            "INFO: {} sequences were skipped because of filters.".format(
+                skipped_sequences_due_to_filters.value
             )
         )
 
@@ -127,9 +176,8 @@ def initialize_multiprocess(
     global_tmp_dir_: str,
     global_config_: dict,
     finished_bbox_sections_: multiprocessing.Value,
+    finished_sequence_id_blocks_: multiprocessing.Value,
     start_date_epoch_: int,
-    pulled_sequences_: multiprocessing.Value,
-    skipped_sequences_due_to_origin_coordinate_: multiprocessing.Value,
     skipped_sequences_due_to_filters_: multiprocessing.Value,
 ) -> None:
     """
@@ -153,21 +201,20 @@ def initialize_multiprocess(
     global finished_bbox_sections
     finished_bbox_sections = finished_bbox_sections_
 
+    # Integer counter of num of finished finished_sequence_id_blocks
+    global finished_sequence_id_blocks
+    finished_sequence_id_blocks = finished_sequence_id_blocks_
+
     global start_date_epoch
     start_date_epoch = start_date_epoch_
-
-    global pulled_sequences
-    pulled_sequences = pulled_sequences_
-
-    global skipped_sequences_due_to_origin_coordinate
-    skipped_sequences_due_to_origin_coordinate = skipped_sequences_due_to_origin_coordinate_
 
     global skipped_sequences_due_to_filters
     skipped_sequences_due_to_filters = skipped_sequences_due_to_filters_
 
 
-def pull_filter_and_save_trace_for_bbox(bbox_section: tuple[int, int, str]) -> None:
+def pull_sequence_ids_for_bbox(bbox_section: tuple[int, int, str]) -> None:
     """
+    FIXME
     Checks to see if a bbox section already has trace data pulled onto disk. If not, pulls it from Mapillary by calling
     make_trace_data_requests(), filters it using trace_filer.run(), and saves it to disk. Writes to a temp file first
     to avoid issues if script crashes during the pickle dump. Meant to be run in a multi-threaded manner and references
@@ -183,13 +230,58 @@ def pull_filter_and_save_trace_for_bbox(bbox_section: tuple[int, int, str]) -> N
         # If either we have already pulled trace data to disk, or if it's been pulled AND processed by map_matching,
         # don't pull it again.
         if os.path.exists(trace_filename) or os.path.exists(processed_trace_filename):
-            print("Seq already exists on disk for tile={}. Skipping...".format(tile))
+            print("Seq IDs already exists on disk for tile={}. Skipping...".format(tile))
+            with finished_bbox_sections.get_lock():
+                finished_bbox_sections.value += 1
+            return
+
+        sequence_ids: set[str] = pull_sequence_ids(session, tile, global_config)
+
+        # Avoids potential partial write issues by writing to a temp file and then as a final operation, then renaming
+        # to the real location
+        temp_filename = os.path.join(
+            global_tmp_dir, "_".join([str(c) for c in tile]) + ".pickle"
+        )
+        pickle.dump(sequence_ids, open(temp_filename, "wb"))
+        os.rename(temp_filename, trace_filename)
+
+        with finished_bbox_sections.get_lock():
+            finished_bbox_sections.value += 1
+    except Exception as e:
+        print("ERROR: Failed to pull sequence IDs: {}".format(repr(e)))
+
+
+def pull_filter_and_save_trace_for_sequence_ids(
+    sequence_id_blocks: tuple[list[str], str]
+) -> None:
+    """
+    FIXME
+    Checks to see if a bbox section already has trace data pulled onto disk. If not, pulls it from Mapillary by calling
+    make_trace_data_requests(), filters it using trace_filer.run(), and saves it to disk. Writes to a temp file first
+    to avoid issues if script crashes during the pickle dump. Meant to be run in a multi-threaded manner and references
+    global vars made by initialize_multiprocess().
+
+    :param bbox_section: tuple where [0:1] indices: [x,y] coordinate of the zoom 14 tile, [2] index: the filename where
+        the pulled trace data should be stored
+    """
+    try:
+        sequence_id_block, trace_filename = sequence_id_blocks[0], sequence_id_blocks[1]
+        processed_trace_filename = util.get_processed_trace_filename(trace_filename)
+
+        # If either we have already pulled trace data to disk, or if it's been pulled AND processed by map_matching,
+        # don't pull it again.
+        if os.path.exists(trace_filename) or os.path.exists(processed_trace_filename):
+            print(
+                "Traces already exists on disk for sequence_id_block={}. Skipping...".format(
+                    sequence_id_block
+                )
+            )
             with finished_bbox_sections.get_lock():
                 finished_bbox_sections.value += 1
             return
 
         # We haven't pulled API trace data for this bbox section yet
-        trace_data = make_trace_data_requests(session, tile, global_config)
+        trace_data = make_trace_data_requests(session, sequence_id_block, global_config)
         before_filter_num_sequences = len(trace_data)
 
         # Perform some simple filters to weed out bad trace data
@@ -205,9 +297,8 @@ def pull_filter_and_save_trace_for_bbox(bbox_section: tuple[int, int, str]) -> N
 
         # Avoids potential partial write issues by writing to a temp file and then as a final operation, then renaming
         # to the real location
-        temp_filename = os.path.join(
-            global_tmp_dir, "_".join([str(c) for c in tile]) + ".pickle"
-        )
+        temp_filename = os.path.join(global_tmp_dir, os.path.basename(trace_filename))
+        print(temp_filename)
         pickle.dump(trace_data, open(temp_filename, "wb"))
         os.rename(temp_filename, trace_filename)
 
@@ -217,31 +308,15 @@ def pull_filter_and_save_trace_for_bbox(bbox_section: tuple[int, int, str]) -> N
         print("ERROR: Failed to pull trace data: {}".format(repr(e)))
 
 
-def make_trace_data_requests(
+def pull_sequence_ids(
     session_: requests.Session, tile: tuple[int, int], conf: any
-) -> list[list[dict]]:
-    """
-    Makes the actual calls to Mapillary API to pull trace data for a given tile at zoom 14.
-
-    :param session_: requests.Session() to persist session across API calls
-    :param tile: Tuple of [x,y] that represents a tile at z14.
-    :param conf: Dict of configs. See "--trace-config" section of README for keys
-    :return: List of trace data sequences. Trace data is in format understood by Valhalla map matching process, i.e. it
-        has 'lon', 'lat', 'time', and optionally 'radius' keys
-    """
-    skip_if_fewer_imgs_than = (
-        conf["skip_if_fewer_images_than"]
-        if "skip_if_fewer_images_than" in conf
-        else SKIP_IF_FEWER_IMAGES_THAN_DEFAULT
-    )
+) -> set[str]:
     max_sequences_per_bbox_section = (
         conf["max_sequences_per_bbox_section"]
         if "max_sequences_per_bbox_section" in conf
         else MAX_SEQUENCES_PER_BBOX_SECTION_DEFAULT
     )
 
-    # We will use this dict to group trace points by sequence ID
-    sequences = []
     # We will use this set to skip sequences we've already processed
     seen_sequences = set()
 
@@ -269,81 +344,101 @@ def make_trace_data_requests(
             if captured_at and captured_at > start_date_epoch:
                 if sequence_id and sequence_id not in seen_sequences:
                     seen_sequences.add(sequence_id)
-                    with pulled_sequences.get_lock():
-                        pulled_sequences.value += 1
 
-                    sequence_resp = session_.get(
-                        SEQUENCE_URL.format(sequence_id, access_token)
-                    )
+        # Already collected enough sequences. Move onto the next bbox section
+        if len(seen_sequences) > max_sequences_per_bbox_section:
+            print(
+                "NOTE: Already collected {} seqs for this bbox section, greater than max_sequences_per_bbox_section={}"
+                ". Continuing...".format(len(seen_sequences), max_sequences_per_bbox_section)
+            )
+            break
 
-                    image_ids = [
-                        img_id_obj["id"] for img_id_obj in sequence_resp.json()["data"]
-                    ]
+    return seen_sequences
 
-                    # Skip sequences that have too few images
-                    if len(image_ids) < skip_if_fewer_imgs_than:
-                        with skipped_sequences_due_to_filters.get_lock():
-                            skipped_sequences_due_to_filters.value += 1
-                        continue
 
-                    images_resp = session_.get(
-                        IMAGES_URL.format(",".join(image_ids), access_token)
-                    )
-                    images = [
-                        {  # Convert to seconds because filtering / map matching assumes time in seconds
-                            "time": img_obj["captured_at"] / 1000,
-                            "lon": img_obj["geometry"]["coordinates"][0],
-                            "lat": img_obj["geometry"]["coordinates"][1],
-                        }
-                        for img_obj in images_resp.json()["data"]
-                    ]
+def make_trace_data_requests(
+    session_: requests.Session, sequence_ids: list[str], conf: any
+) -> list[list[dict]]:
+    """
+    FIXME
+    Makes the actual calls to Mapillary API to pull trace data for a given tile at zoom 14.
 
-                    # Mapillary returns their trace data in random chronological order, so we need to sort the images
-                    images = sorted(images, key=lambda x: x["time"])
+    :param session_: requests.Session() to persist session across API calls
+    :param tile: Tuple of [x,y] that represents a tile at z14.
+    :param conf: Dict of configs. See "--trace-config" section of README for keys
+    :return: List of trace data sequences. Trace data is in format understood by Valhalla map matching process, i.e. it
+        has 'lon', 'lat', 'time', and optionally 'radius' keys
+    """
+    skip_if_fewer_imgs_than = (
+        conf["skip_if_fewer_images_than"]
+        if "skip_if_fewer_images_than" in conf
+        else SKIP_IF_FEWER_IMAGES_THAN_DEFAULT
+    )
 
-                    # Only process sequences that originated from this bbox. This prevents us from processing sequences
-                    # twice
-                    origin_lon, origin_lat = (
-                        images[0]["lon"],
-                        images[0]["lat"],
-                    )
+    sequences = []
+    for sequence_id in sequence_ids:
+        sequence_resp = session_.get(SEQUENCE_URL.format(sequence_id, access_token))
+        image_ids = [img_id_obj["id"] for img_id_obj in sequence_resp.json()["data"]]
 
-                    # We need to check if this specific sequence is covered by this zoom 14 tile. We do this by getting
-                    # the lon, lat coordinates of this tile and checking the first coordinate of the sequence. This way
-                    # we prevent the same sequence being processed by multiple different threads / zoom 14 tiles
-                    upper_left_corner = get_lon_lat_from_tile(
-                        BBOX_SECTION_ZOOM, tile[0], tile[1]
-                    )
-                    lower_right_corner = get_lon_lat_from_tile(
-                        BBOX_SECTION_ZOOM, tile[0] + 1, tile[1] + 1
-                    )
-                    cur_tile_as_lon_lat = [
-                        upper_left_corner[0],
-                        lower_right_corner[1],
-                        lower_right_corner[0],
-                        upper_left_corner[1],
-                    ]
-                    if not is_within_bbox(origin_lon, origin_lat, cur_tile_as_lon_lat):
-                        with skipped_sequences_due_to_origin_coordinate.get_lock():
-                            skipped_sequences_due_to_origin_coordinate.value += 1
-                        continue
+        # Skip sequences that have too few images
+        if len(image_ids) < skip_if_fewer_imgs_than:
+            with skipped_sequences_due_to_filters.get_lock():
+                skipped_sequences_due_to_filters.value += 1
+            continue
 
-                    sequences.append(images)
+        images_resp = session_.get(IMAGES_URL.format(",".join(image_ids), access_token))
+        images = [
+            {  # Convert to seconds because filtering / map matching assumes time in seconds
+                "time": img_obj["captured_at"] / 1000,
+                "lon": img_obj["geometry"]["coordinates"][0],
+                "lat": img_obj["geometry"]["coordinates"][1],
+            }
+            for img_obj in images_resp.json()["data"]
+        ]
 
-            # Already collected enough sequences. Move onto the next bbox section
-            if len(sequences) > max_sequences_per_bbox_section:
-                print(
-                    "## Already collected {} seqs for this bbox section, greater than max_sequences_per_bbox_section={}"
-                    ". Continuing...".format(len(sequences), max_sequences_per_bbox_section)
-                )
-                break
+        # Mapillary returns their trace data in random chronological order, so we need to sort the images
+        images = sorted(images, key=lambda x: x["time"])
+
+        sequences.append(images)
 
     return sequences
 
 
+def find_unique_sequence_ids(bbox_sections, traces_dir) -> list[tuple[list[str], str]]:
+    # FIXME: Docstring and types
+    unique_sequence_ids: set[str] = set()
+    total_sequence_ids_count = 0
+
+    for bbox_section in bbox_sections:
+        trace_filename = bbox_section[-1]
+        sequence_ids: set[str] = pickle.load(open(trace_filename, "rb"))
+        unique_sequence_ids.update(sequence_ids)
+        total_sequence_ids_count += len(sequence_ids)
+
+    print(
+        "INFO: Out of {} sequence IDs, {} were unique.".format(
+            total_sequence_ids_count, len(unique_sequence_ids)
+        )
+    )
+
+    sequence_id_blocks = []
+    unique_sequence_ids_list: list[str] = list(unique_sequence_ids)
+    block_num = 0
+    for i in range(0, len(unique_sequence_ids_list), SEQUENCE_ID_BLOCK_SIZE):
+        trace_filename = os.path.join(traces_dir, "block_{}.pickle".format(block_num))
+
+        sequence_id_blocks.append(
+            (unique_sequence_ids_list[i : i + SEQUENCE_ID_BLOCK_SIZE], trace_filename)
+        )
+
+        block_num += 1
+
+    return sequence_id_blocks
+
+
 def split_bbox(
     session_: requests.Session,
-    traces_dir: str,
+    storage_dir: str,
     bbox: str,
     access_token_: str,
     start_date_epoch: float,
@@ -353,14 +448,14 @@ def split_bbox(
     tiles that we should call to find trace sequences.
 
     :param session_: requests session
-    :param traces_dir: name of dir where traces should be stored
+    :param storage_dir: name of dir where results from this step should be stored
     :param bbox: bbox string from arg
     :param access_token_: Mapillary v4 access token (obtained through OAuth)
     :param start_date_epoch: Epoch timestamp; any traces taken at a time older than this timestamp will be rejected
     :return: list of tuples, [0:1] indices: [x,y] coordinate of the zoom 14 tile, [2] index: the filename where the
         pulled trace data should be stored
     """
-    sections_filename = util.get_sections_filename(traces_dir)
+    sections_filename = util.get_sections_filename(storage_dir)
 
     try:
         print("Reading bbox_sections from disk...")
@@ -392,7 +487,7 @@ def split_bbox(
             for y in range(start_y, end_y + 1):
                 # Create a dir to store trace data for this zoom 5 tile
                 zoom_5_dir = os.path.join(
-                    traces_dir, "_".join([str(COVERAGE_ZOOM), str(x), str(y)])
+                    storage_dir, "_".join([str(COVERAGE_ZOOM), str(x), str(y)])
                 )
                 if not os.path.exists(zoom_5_dir):
                     os.makedirs(zoom_5_dir)
@@ -420,7 +515,7 @@ def split_bbox(
                         min_lat,
                         max_lon,
                         max_lat,
-                        traces_dir,
+                        storage_dir,
                     )
                 )
 
@@ -440,7 +535,7 @@ def z14_tiles_from_coverage_tile_to_bbox_sections(
     min_lat: float,
     max_lon: float,
     max_lat: float,
-    traces_dir: str,
+    storage_dir: str,
 ) -> list[tuple[int, int, str]]:
     """
     Parses the given tile_pb (which is the protobuf of a Mapillary zoom 5 coverage tile), and determines which zoom 14
@@ -459,7 +554,7 @@ def z14_tiles_from_coverage_tile_to_bbox_sections(
     :param min_lat: of the original bbox of the run
     :param max_lon: of the original bbox of the run
     :param max_lat: of the original bbox of the run
-    :param traces_dir: str where we should store the traces output
+    :param storage_dir: name of dir where results from this step should be stored
     :return: zoom 14 tiles that we will need to traverse for trace sequences
     """
     found_zoom_14_tiles = []
@@ -525,8 +620,8 @@ def z14_tiles_from_coverage_tile_to_bbox_sections(
                             candidate_max_lat,
                         ):
                             # The file on disk where we will store trace data, with a dir
-                            trace_filename = os.path.join(
-                                traces_dir,
+                            storage_filename = os.path.join(
+                                storage_dir,
                                 "_".join([str(COVERAGE_ZOOM), str(x), str(y)]),
                                 "_".join(
                                     [
@@ -539,7 +634,7 @@ def z14_tiles_from_coverage_tile_to_bbox_sections(
                             )
 
                             zoom_14_tiles_in_bbox.append(
-                                (candidate_x, candidate_y, trace_filename)
+                                (candidate_x, candidate_y, storage_filename)
                             )
                     found_zoom_14_tiles.extend(zoom_14_tiles_in_bbox)
 


### PR DESCRIPTION
Fixes #11 
* Adds a separate multi-processed flow where it pulls all the applicable Mapillary sequence IDs as a first step
  * Then, it reads all these sequence IDs into memory and uniques them
  * These unique IDs are broken up into chunks of size 10 and stored on disk as interim step
* The multi-processed flow that pulls trace data per sequence then reads from the step described above and only pulls traces for these unique IDs, saving us time
* Small updates to README
* Removes `tmp` dir at the end of runs