### PR TITLE
Changes all prints to use the logging module

### DIFF
--- a/conflation/aggregation.py
+++ b/conflation/aggregation.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import logging
 import os
 import pandas as pd
 import pickle
@@ -72,7 +73,7 @@ def run(map_matches_dir: str, results_dir: str) -> None:
     # Check to see if the final result has already been processed
     final_config_filename = util.get_final_config_filename(results_dir)
     if os.path.exists(final_config_filename):
-        print("Final config already built. Skipping...")
+        logging.info("Final config already built. Skipping...")
         return
 
     final_config = []
@@ -89,14 +90,14 @@ def run(map_matches_dir: str, results_dir: str) -> None:
             # Pull map matches from disk
             map_match_data_filename = os.path.join(subdir, file)
             try:
-                print(
+                logging.info(
                     "Reading {}/{} map match results from file {}".format(
                         country, region, map_match_data_filename
                     )
                 )
                 map_match_data: list[tuple] = pickle.load(open(map_match_data_filename, "rb"))
             except (OSError, IOError):
-                print("ERROR: {} pickle could not be loaded. Cannot perform aggregation.")
+                logging.critical("{} pickle could not be loaded. Cannot perform aggregation.")
                 continue
 
             # Combine the data with other data from the same region
@@ -189,6 +190,6 @@ def measurements_to_config(
         elif type_ in ["driveway", "alley", "parking_aisle", "drive-through"]:
             config[density][type_] = kph
         else:
-            print("WARNING: type {} not supported".format(type))
+            logging.warning("Type {} not supported".format(type))
 
     return config

--- a/conflation/trace_fetching/auth_server.py
+++ b/conflation/trace_fetching/auth_server.py
@@ -11,6 +11,7 @@ continue with the rest of the work
 Usage::
     ./server.py mapillary_client_id mapillary_client_secret
 """
+import logging
 import requests
 import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -58,12 +59,12 @@ def run(
 
     server_address = ("localhost", port)
     httpd = server_class(server_address, handler_class)
-    print("Starting httpd and opening Mapillary to authenticate...")
+    logging.info("Starting httpd and opening Mapillary to authenticate...")
     try:
         webbrowser.open_new_tab(AUTH_URL.format(client_id))
         httpd.serve_forever()
     except KeyboardInterrupt:
         pass
     httpd.server_close()
-    print("Stopping httpd...")
+    logging.info("Stopping httpd...")
     return access_token

--- a/conflation/trace_fetching/mapillary.py
+++ b/conflation/trace_fetching/mapillary.py
@@ -299,8 +299,8 @@ def pull_filter_and_save_trace_for_sequence_ids(
         pickle.dump(trace_data, open(temp_filename, "wb"))
         os.rename(temp_filename, trace_filename)
 
-        with finished_bbox_sections.get_lock():
-            finished_bbox_sections.value += 1
+        with finished_sequence_id_blocks.get_lock():
+            finished_sequence_id_blocks.value += 1
     except Exception as e:
         logging.error("Failed to pull trace data: {}".format(repr(e)))
 

--- a/conflation/trace_filter.py
+++ b/conflation/trace_filter.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 from math import radians, cos, sin, asin, sqrt
 
@@ -37,8 +38,10 @@ def run(trace_data: list[list[dict]]) -> list[list[dict]]:
 
         # Skip if time spent on sequence isn't long enough
         if sequence[-1]["time"] - sequence[0]["time"] < MINIMUM_TOTAL_TIME:
-            print(
-                "Skipping b/c min time {}".format(sequence[-1]["time"] - sequence[0]["time"])
+            logging.debug(
+                "Skipping trace b/c min time {}".format(
+                    sequence[-1]["time"] - sequence[0]["time"]
+                )
             )
             continue
 
@@ -67,7 +70,7 @@ def run(trace_data: list[list[dict]]) -> list[list[dict]]:
             # than a previous trace's timestamp, something is wrong with this sequence so we will throw it away to
             # be safe
             if t < 0:
-                print("Skipping b/c min time < 0")
+                logging.debug("Skipping trace b/c min time < 0")
                 should_skip_sequence = True
 
             # Skip calculating speed for this specific trace point if no time elapsed
@@ -88,21 +91,23 @@ def run(trace_data: list[list[dict]]) -> list[list[dict]]:
             speeds.append(v_kmph)
 
         if should_skip_sequence:
-            print("Skipping b/c should skip seq")
+            logging.debug("Skipping trace b/c should skip seq")
             continue
 
         if num_poor_measurements / len(sequence) > MAXIMUM_POOR_MEASUREMENTS_PERCENT:
-            print("Skipping b/c too many latent traces {}".format(num_poor_measurements))
+            logging.debug(
+                "Skipping trace b/c too many latent traces {}".format(num_poor_measurements)
+            )
             continue
 
         # Skip if distance traveled on sequence isn't long enough
         if total_dist < MINIMUM_TOTAL_DISTANCE:
-            print("Skipping b/c min total dist {}".format(total_dist))
+            logging.debug("Skipping trace b/c min total dist {}".format(total_dist))
             continue
 
         # Skip if we feel like the average speed in this sequence isn't fast enough correspond with someone driving
         if np.array(speeds).mean() < MINIMUM_MEAN_SPEED:
-            print("Skipping b/c mean speed {}".format(np.array(speeds).mean()))
+            logging.debug("Skipping trace b/c mean speed {}".format(np.array(speeds).mean()))
             continue
 
         filtered_trace_data.append(sequence)

--- a/conflation/util.py
+++ b/conflation/util.py
@@ -13,12 +13,12 @@ FINAL_RESULTS_FILENAME = "config.json"
 MAP_MATCH_REGION_FILENAME_DELIMITER = "-"
 
 
-def initialize_dirs(bbox_str: str) -> tuple[str, str, str, str]:
+def initialize_dirs(bbox_str: str) -> tuple[str, str, str, str, str]:
     """
     Creates all dirs needed for run if they don't exist.
 
     :param bbox_str: bbox string from arg :return: tuple of (traces dir name, tmp dir name for any tmp pickle files,
-        map match results dir name, final results dir name)
+        map match results dir name, final results dir name, path to where the log should be stored)
     """
 
     # Use a hash function to generate an "ID" for this bbox. Helped to detect duplicate runs.
@@ -30,11 +30,11 @@ def initialize_dirs(bbox_str: str) -> tuple[str, str, str, str]:
         os.path.dirname(os.getcwd()), OUTPUT_DIR, bbox, MAP_MATCH_DIR
     )
     results_dir = os.path.join(os.path.dirname(os.getcwd()), OUTPUT_DIR, bbox, RESULTS_DIR)
-    # Make the output tmp, and result dirs if it does not exist yet
-    if not os.path.exists(tmp_dir):
-        os.makedirs(  # Makes all dirs recursively, so we know "output/" will also now exist
-            traces_dir
-        )
+    log_filename = os.path.join(os.path.dirname(os.getcwd()), OUTPUT_DIR, bbox, "run.log")
+
+    # Make the dirs if it does not exist yet. Makes all dirs recursively, so we know "output/" will also now exist
+    if not os.path.exists(traces_dir):
+        os.makedirs(traces_dir)
     if not os.path.exists(tmp_dir):
         os.makedirs(tmp_dir)
     if not os.path.exists(map_matches_dir):
@@ -42,7 +42,7 @@ def initialize_dirs(bbox_str: str) -> tuple[str, str, str, str]:
     if not os.path.exists(results_dir):
         os.makedirs(results_dir)
 
-    return traces_dir, tmp_dir, map_matches_dir, results_dir
+    return traces_dir, tmp_dir, map_matches_dir, results_dir, log_filename
 
 
 def get_sha1_truncated_id(s: str) -> str:


### PR DESCRIPTION
* Changes all `print()` statements to use `logging` instead
  * Creates a `run.log` file in the `output/` dir to store the logs, as well as printing them to stderr
* Adds a timestamp to report how long runs take
* Small bug fixes in Mapillary flow